### PR TITLE
Add width and addressBlock tags

### DIFF
--- a/ci/regtest/PIC32MX170F256B.svd
+++ b/ci/regtest/PIC32MX170F256B.svd
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <device>
   <name>PIC32MX170F256B</name>
+  <width>32</width>
   <peripherals>
     <peripheral>
       <name>WDT</name>
       <description>WDT peripheral</description>
       <baseAddress>0xbf800000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>WDTCON</name>
@@ -113,6 +119,11 @@
       <name>RTCC</name>
       <description>RTCC peripheral</description>
       <baseAddress>0xbf800200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RTCCON</name>
@@ -976,6 +987,11 @@
       <name>TMR1</name>
       <description>TMR1 peripheral</description>
       <baseAddress>0xbf800600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T1CON</name>
@@ -1267,6 +1283,11 @@
       <name>TMR2</name>
       <description>TMR2 peripheral</description>
       <baseAddress>0xbf800800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T2CON</name>
@@ -1526,6 +1547,11 @@
       <name>TMR3</name>
       <description>TMR3 peripheral</description>
       <baseAddress>0xbf800a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T3CON</name>
@@ -1769,6 +1795,11 @@
       <name>TMR4</name>
       <description>TMR4 peripheral</description>
       <baseAddress>0xbf800c00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T4CON</name>
@@ -2028,6 +2059,11 @@
       <name>TMR5</name>
       <description>TMR5 peripheral</description>
       <baseAddress>0xbf800e00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T5CON</name>
@@ -2271,6 +2307,11 @@
       <name>ICAP1</name>
       <description>ICAP1 peripheral</description>
       <baseAddress>0xbf802000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC1CON</name>
@@ -2487,6 +2528,11 @@
       <name>ICAP2</name>
       <description>ICAP2 peripheral</description>
       <baseAddress>0xbf802200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC2CON</name>
@@ -2703,6 +2749,11 @@
       <name>ICAP3</name>
       <description>ICAP3 peripheral</description>
       <baseAddress>0xbf802400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC3CON</name>
@@ -2919,6 +2970,11 @@
       <name>ICAP4</name>
       <description>ICAP4 peripheral</description>
       <baseAddress>0xbf802600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC4CON</name>
@@ -3135,6 +3191,11 @@
       <name>ICAP5</name>
       <description>ICAP5 peripheral</description>
       <baseAddress>0xbf802800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC5CON</name>
@@ -3351,6 +3412,11 @@
       <name>OCMP1</name>
       <description>OCMP1 peripheral</description>
       <baseAddress>0xbf803000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC1CON</name>
@@ -3610,6 +3676,11 @@
       <name>OCMP2</name>
       <description>OCMP2 peripheral</description>
       <baseAddress>0xbf803200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC2CON</name>
@@ -3869,6 +3940,11 @@
       <name>OCMP3</name>
       <description>OCMP3 peripheral</description>
       <baseAddress>0xbf803400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC3CON</name>
@@ -4128,6 +4204,11 @@
       <name>OCMP4</name>
       <description>OCMP4 peripheral</description>
       <baseAddress>0xbf803600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC4CON</name>
@@ -4387,6 +4468,11 @@
       <name>OCMP5</name>
       <description>OCMP5 peripheral</description>
       <baseAddress>0xbf803800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC5CON</name>
@@ -4646,6 +4732,11 @@
       <name>I2C1</name>
       <description>I2C1 peripheral</description>
       <baseAddress>0xbf805000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C1CON</name>
@@ -5410,6 +5501,11 @@
       <name>I2C2</name>
       <description>I2C2 peripheral</description>
       <baseAddress>0xbf805100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C2CON</name>
@@ -6174,6 +6270,11 @@
       <name>SPI1</name>
       <description>SPI1 peripheral</description>
       <baseAddress>0xbf805800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI1CON</name>
@@ -7042,6 +7143,11 @@
       <name>SPI2</name>
       <description>SPI2 peripheral</description>
       <baseAddress>0xbf805a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI2CON</name>
@@ -7910,6 +8016,11 @@
       <name>UART1</name>
       <description>UART1 peripheral</description>
       <baseAddress>0xbf806000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1MODE</name>
@@ -8531,6 +8642,11 @@
       <name>UART2</name>
       <description>UART2 peripheral</description>
       <baseAddress>0xbf806200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U2MODE</name>
@@ -9152,6 +9268,11 @@
       <name>PMP</name>
       <description>PMP peripheral</description>
       <baseAddress>0xbf807000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>PMCON</name>
@@ -9987,6 +10108,11 @@
       <name>ADC10</name>
       <description>ADC10 peripheral</description>
       <baseAddress>0xbf809000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x170</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>AD1CON1</name>
@@ -10766,6 +10892,11 @@
       <name>CVR</name>
       <description>CVR peripheral</description>
       <baseAddress>0xbf809800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CVRCON</name>
@@ -10889,6 +11020,11 @@
       <name>CMP1</name>
       <description>CMP1 peripheral</description>
       <baseAddress>0xbf80a000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM1CON</name>
@@ -11044,6 +11180,11 @@
       <name>CMP2</name>
       <description>CMP2 peripheral</description>
       <baseAddress>0xbf80a010</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM2CON</name>
@@ -11199,6 +11340,11 @@
       <name>CMP3</name>
       <description>CMP3 peripheral</description>
       <baseAddress>0xbf80a020</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM3CON</name>
@@ -11354,6 +11500,11 @@
       <name>CMP</name>
       <description>CMP peripheral</description>
       <baseAddress>0xbf80a060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CMSTAT</name>
@@ -11477,6 +11628,11 @@
       <name>CTMU</name>
       <description>CTMU peripheral</description>
       <baseAddress>0xbf80a200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CTMUCON</name>
@@ -11808,6 +11964,11 @@
       <name>OSC</name>
       <description>OSC peripheral</description>
       <baseAddress>0xbf80f000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OSCCON</name>
@@ -12391,6 +12552,11 @@
       <name>CFG</name>
       <description>CFG peripheral</description>
       <baseAddress>0xbf80f200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CFGCON</name>
@@ -13188,6 +13354,11 @@
       <name>NVM</name>
       <description>NVM peripheral</description>
       <baseAddress>0xbf80f400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>NVMCON</name>
@@ -13418,6 +13589,11 @@
       <name>RCON</name>
       <description>RCON peripheral</description>
       <baseAddress>0xbf80f600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RCON</name>
@@ -13657,6 +13833,11 @@
       <name>PPS</name>
       <description>PPS peripheral</description>
       <baseAddress>0xbf80fa04</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x19c</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INT1R</name>
@@ -14405,6 +14586,11 @@
       <name>INT</name>
       <description>INT peripheral</description>
       <baseAddress>0xbf881000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x140</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INTCON</name>
@@ -18765,6 +18951,11 @@
       <name>BMX</name>
       <description>BMX peripheral</description>
       <baseAddress>0xbf882000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>BMXCON</name>
@@ -19183,6 +19374,11 @@
       <name>DMAC</name>
       <description>DMAC peripheral</description>
       <baseAddress>0xbf883000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DMACON</name>
@@ -19678,6 +19874,11 @@
       <name>DMAC0</name>
       <description>DMAC0 peripheral</description>
       <baseAddress>0xbf883060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH0CON</name>
@@ -20757,6 +20958,11 @@
       <name>DMAC1</name>
       <description>DMAC1 peripheral</description>
       <baseAddress>0xbf883120</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH1CON</name>
@@ -21836,6 +22042,11 @@
       <name>DMAC2</name>
       <description>DMAC2 peripheral</description>
       <baseAddress>0xbf8831e0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH2CON</name>
@@ -22915,6 +23126,11 @@
       <name>DMAC3</name>
       <description>DMAC3 peripheral</description>
       <baseAddress>0xbf8832a0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH3CON</name>
@@ -23994,6 +24210,11 @@
       <name>USB</name>
       <description>USB peripheral</description>
       <baseAddress>0xbf885040</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x3c0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1OTGIR</name>
@@ -27583,6 +27804,11 @@
       <name>PORTA</name>
       <description>PORTA peripheral</description>
       <baseAddress>0xbf886000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELA</name>
@@ -28670,6 +28896,11 @@
       <name>PORTB</name>
       <description>PORTB peripheral</description>
       <baseAddress>0xbf886100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELB</name>

--- a/ci/regtest/PIC32MX274F256B.svd
+++ b/ci/regtest/PIC32MX274F256B.svd
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <device>
   <name>PIC32MX274F256B</name>
+  <width>32</width>
   <peripherals>
     <peripheral>
       <name>DSCTRL</name>
       <description>DSCTRL peripheral</description>
       <baseAddress>0xbf800000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xcc</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DSCON</name>
@@ -508,6 +514,11 @@
       <name>RTCC</name>
       <description>RTCC peripheral</description>
       <baseAddress>0xbf800200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RTCCON</name>
@@ -1387,6 +1398,11 @@
       <name>TMR1</name>
       <description>TMR1 peripheral</description>
       <baseAddress>0xbf800600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T1CON</name>
@@ -1694,6 +1710,11 @@
       <name>TMR2</name>
       <description>TMR2 peripheral</description>
       <baseAddress>0xbf800800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T2CON</name>
@@ -1953,6 +1974,11 @@
       <name>TMR3</name>
       <description>TMR3 peripheral</description>
       <baseAddress>0xbf800a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T3CON</name>
@@ -2196,6 +2222,11 @@
       <name>TMR4</name>
       <description>TMR4 peripheral</description>
       <baseAddress>0xbf800c00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T4CON</name>
@@ -2455,6 +2486,11 @@
       <name>TMR5</name>
       <description>TMR5 peripheral</description>
       <baseAddress>0xbf800e00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T5CON</name>
@@ -2698,6 +2734,11 @@
       <name>ICAP1</name>
       <description>ICAP1 peripheral</description>
       <baseAddress>0xbf802000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC1CON</name>
@@ -2914,6 +2955,11 @@
       <name>ICAP2</name>
       <description>ICAP2 peripheral</description>
       <baseAddress>0xbf802200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC2CON</name>
@@ -3130,6 +3176,11 @@
       <name>ICAP3</name>
       <description>ICAP3 peripheral</description>
       <baseAddress>0xbf802400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC3CON</name>
@@ -3346,6 +3397,11 @@
       <name>ICAP4</name>
       <description>ICAP4 peripheral</description>
       <baseAddress>0xbf802600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC4CON</name>
@@ -3562,6 +3618,11 @@
       <name>ICAP5</name>
       <description>ICAP5 peripheral</description>
       <baseAddress>0xbf802800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC5CON</name>
@@ -3778,6 +3839,11 @@
       <name>OCMP1</name>
       <description>OCMP1 peripheral</description>
       <baseAddress>0xbf803000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC1CON</name>
@@ -4037,6 +4103,11 @@
       <name>OCMP2</name>
       <description>OCMP2 peripheral</description>
       <baseAddress>0xbf803200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC2CON</name>
@@ -4296,6 +4367,11 @@
       <name>OCMP3</name>
       <description>OCMP3 peripheral</description>
       <baseAddress>0xbf803400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC3CON</name>
@@ -4555,6 +4631,11 @@
       <name>OCMP4</name>
       <description>OCMP4 peripheral</description>
       <baseAddress>0xbf803600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC4CON</name>
@@ -4814,6 +4895,11 @@
       <name>OCMP5</name>
       <description>OCMP5 peripheral</description>
       <baseAddress>0xbf803800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC5CON</name>
@@ -5073,6 +5159,11 @@
       <name>I2C1</name>
       <description>I2C1 peripheral</description>
       <baseAddress>0xbf805000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C1CON</name>
@@ -5837,6 +5928,11 @@
       <name>I2C2</name>
       <description>I2C2 peripheral</description>
       <baseAddress>0xbf805100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C2CON</name>
@@ -6601,6 +6697,11 @@
       <name>SPI1</name>
       <description>SPI1 peripheral</description>
       <baseAddress>0xbf805800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI1CON</name>
@@ -7469,6 +7570,11 @@
       <name>SPI2</name>
       <description>SPI2 peripheral</description>
       <baseAddress>0xbf805a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI2CON</name>
@@ -8337,6 +8443,11 @@
       <name>UART1</name>
       <description>UART1 peripheral</description>
       <baseAddress>0xbf806000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1MODE</name>
@@ -9022,6 +9133,11 @@
       <name>UART2</name>
       <description>UART2 peripheral</description>
       <baseAddress>0xbf806200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U2MODE</name>
@@ -9707,6 +9823,11 @@
       <name>PMP</name>
       <description>PMP peripheral</description>
       <baseAddress>0xbf807000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>PMCON</name>
@@ -10746,6 +10867,11 @@
       <name>ADC10</name>
       <description>ADC10 peripheral</description>
       <baseAddress>0xbf809000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x170</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>AD1CON1</name>
@@ -11724,6 +11850,11 @@
       <name>CVR</name>
       <description>CVR peripheral</description>
       <baseAddress>0xbf809800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CVRCON</name>
@@ -11847,6 +11978,11 @@
       <name>CMP1</name>
       <description>CMP1 peripheral</description>
       <baseAddress>0xbf80a000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM1CON</name>
@@ -12002,6 +12138,11 @@
       <name>CMP2</name>
       <description>CMP2 peripheral</description>
       <baseAddress>0xbf80a010</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM2CON</name>
@@ -12157,6 +12298,11 @@
       <name>CMP3</name>
       <description>CMP3 peripheral</description>
       <baseAddress>0xbf80a020</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM3CON</name>
@@ -12312,6 +12458,11 @@
       <name>CMP</name>
       <description>CMP peripheral</description>
       <baseAddress>0xbf80a060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CMSTAT</name>
@@ -12435,6 +12586,11 @@
       <name>CTMU</name>
       <description>CTMU peripheral</description>
       <baseAddress>0xbf80a200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CTMUCON</name>
@@ -12766,6 +12922,11 @@
       <name>CRU</name>
       <description>CRU peripheral</description>
       <baseAddress>0xbf80f000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x1e0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OSCCON</name>
@@ -14165,6 +14326,11 @@
       <name>CFG</name>
       <description>CFG peripheral</description>
       <baseAddress>0xbf80f200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CFGCON</name>
@@ -15002,6 +15168,11 @@
       <name>NVM</name>
       <description>NVM peripheral</description>
       <baseAddress>0xbf80f400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>NVMCON</name>
@@ -15232,6 +15403,11 @@
       <name>WDT</name>
       <description>WDT peripheral</description>
       <baseAddress>0xbf80f600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>WDTCON</name>
@@ -15339,6 +15515,11 @@
       <name>PPS</name>
       <description>PPS peripheral</description>
       <baseAddress>0xbf80fa04</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x19c</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INT1R</name>
@@ -16074,6 +16255,11 @@
       <name>HLVD</name>
       <description>HLVD peripheral</description>
       <baseAddress>0xbf80fc00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>HLVDCON</name>
@@ -16213,6 +16399,11 @@
       <name>INT</name>
       <description>INT peripheral</description>
       <baseAddress>0xbf881000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x140</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INTCON</name>
@@ -20641,6 +20832,11 @@
       <name>BMX</name>
       <description>BMX peripheral</description>
       <baseAddress>0xbf882000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>BMXCON</name>
@@ -21059,6 +21255,11 @@
       <name>DMAC</name>
       <description>DMAC peripheral</description>
       <baseAddress>0xbf883000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DMACON</name>
@@ -21554,6 +21755,11 @@
       <name>DMAC0</name>
       <description>DMAC0 peripheral</description>
       <baseAddress>0xbf883060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH0CON</name>
@@ -22633,6 +22839,11 @@
       <name>DMAC1</name>
       <description>DMAC1 peripheral</description>
       <baseAddress>0xbf883120</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH1CON</name>
@@ -23712,6 +23923,11 @@
       <name>DMAC2</name>
       <description>DMAC2 peripheral</description>
       <baseAddress>0xbf8831e0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH2CON</name>
@@ -24791,6 +25007,11 @@
       <name>DMAC3</name>
       <description>DMAC3 peripheral</description>
       <baseAddress>0xbf8832a0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH3CON</name>
@@ -25870,6 +26091,11 @@
       <name>PCACHE</name>
       <description>PCACHE peripheral</description>
       <baseAddress>0xbf884000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xd0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CHECON</name>
@@ -26324,6 +26550,11 @@
       <name>USB</name>
       <description>USB peripheral</description>
       <baseAddress>0xbf885040</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x3c0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1OTGIR</name>
@@ -29913,6 +30144,11 @@
       <name>PORTA</name>
       <description>PORTA peripheral</description>
       <baseAddress>0xbf886000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELA</name>
@@ -31000,6 +31236,11 @@
       <name>PORTB</name>
       <description>PORTB peripheral</description>
       <baseAddress>0xbf886100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELB</name>

--- a/ci/regtest/PIC32MX470F512H.svd
+++ b/ci/regtest/PIC32MX470F512H.svd
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <device>
   <name>PIC32MX470F512H</name>
+  <width>32</width>
   <peripherals>
     <peripheral>
       <name>INT</name>
       <description>INT peripheral</description>
       <baseAddress>0xbf881000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x150</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INTCON</name>
@@ -4866,6 +4872,11 @@
       <name>BMX</name>
       <description>BMX peripheral</description>
       <baseAddress>0xbf882000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>BMXCON</name>
@@ -5284,6 +5295,11 @@
       <name>DMAC</name>
       <description>DMAC peripheral</description>
       <baseAddress>0xbf883000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DMACON</name>
@@ -5779,6 +5795,11 @@
       <name>DMAC0</name>
       <description>DMAC0 peripheral</description>
       <baseAddress>0xbf883060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH0CON</name>
@@ -6858,6 +6879,11 @@
       <name>DMAC1</name>
       <description>DMAC1 peripheral</description>
       <baseAddress>0xbf883120</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH1CON</name>
@@ -7937,6 +7963,11 @@
       <name>DMAC2</name>
       <description>DMAC2 peripheral</description>
       <baseAddress>0xbf8831e0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH2CON</name>
@@ -9016,6 +9047,11 @@
       <name>DMAC3</name>
       <description>DMAC3 peripheral</description>
       <baseAddress>0xbf8832a0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH3CON</name>
@@ -10095,6 +10131,11 @@
       <name>PCACHE</name>
       <description>PCACHE peripheral</description>
       <baseAddress>0xbf884000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xd0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CHECON</name>
@@ -10549,6 +10590,11 @@
       <name>USB</name>
       <description>USB peripheral</description>
       <baseAddress>0xbf885040</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x3c0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1OTGIR</name>
@@ -14138,6 +14184,11 @@
       <name>PORTB</name>
       <description>PORTB peripheral</description>
       <baseAddress>0xbf886100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELB</name>
@@ -16857,6 +16908,11 @@
       <name>PORTC</name>
       <description>PORTC peripheral</description>
       <baseAddress>0xbf886200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELC</name>
@@ -17848,6 +17904,11 @@
       <name>PORTD</name>
       <description>PORTD peripheral</description>
       <baseAddress>0xbf886300</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELD</name>
@@ -19847,6 +19908,11 @@
       <name>PORTE</name>
       <description>PORTE peripheral</description>
       <baseAddress>0xbf886400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELE</name>
@@ -21366,6 +21432,11 @@
       <name>PORTF</name>
       <description>PORTF peripheral</description>
       <baseAddress>0xbf886500</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELF</name>
@@ -22417,6 +22488,11 @@
       <name>PORTG</name>
       <description>PORTG peripheral</description>
       <baseAddress>0xbf886600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ANSELG</name>
@@ -23408,6 +23484,11 @@
       <name>WDT</name>
       <description>WDT peripheral</description>
       <baseAddress>0xbf800000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>WDTCON</name>
@@ -23515,6 +23596,11 @@
       <name>RTCC</name>
       <description>RTCC peripheral</description>
       <baseAddress>0xbf800200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RTCCON</name>
@@ -24378,6 +24464,11 @@
       <name>TMR1</name>
       <description>TMR1 peripheral</description>
       <baseAddress>0xbf800600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T1CON</name>
@@ -24669,6 +24760,11 @@
       <name>TMR2</name>
       <description>TMR2 peripheral</description>
       <baseAddress>0xbf800800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T2CON</name>
@@ -24928,6 +25024,11 @@
       <name>TMR3</name>
       <description>TMR3 peripheral</description>
       <baseAddress>0xbf800a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T3CON</name>
@@ -25171,6 +25272,11 @@
       <name>TMR4</name>
       <description>TMR4 peripheral</description>
       <baseAddress>0xbf800c00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T4CON</name>
@@ -25430,6 +25536,11 @@
       <name>TMR5</name>
       <description>TMR5 peripheral</description>
       <baseAddress>0xbf800e00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T5CON</name>
@@ -25673,6 +25784,11 @@
       <name>ICAP1</name>
       <description>ICAP1 peripheral</description>
       <baseAddress>0xbf802000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC1CON</name>
@@ -25889,6 +26005,11 @@
       <name>ICAP2</name>
       <description>ICAP2 peripheral</description>
       <baseAddress>0xbf802200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC2CON</name>
@@ -26105,6 +26226,11 @@
       <name>ICAP3</name>
       <description>ICAP3 peripheral</description>
       <baseAddress>0xbf802400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC3CON</name>
@@ -26321,6 +26447,11 @@
       <name>ICAP4</name>
       <description>ICAP4 peripheral</description>
       <baseAddress>0xbf802600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC4CON</name>
@@ -26537,6 +26668,11 @@
       <name>ICAP5</name>
       <description>ICAP5 peripheral</description>
       <baseAddress>0xbf802800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC5CON</name>
@@ -26753,6 +26889,11 @@
       <name>OCMP1</name>
       <description>OCMP1 peripheral</description>
       <baseAddress>0xbf803000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC1CON</name>
@@ -27012,6 +27153,11 @@
       <name>OCMP2</name>
       <description>OCMP2 peripheral</description>
       <baseAddress>0xbf803200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC2CON</name>
@@ -27271,6 +27417,11 @@
       <name>OCMP3</name>
       <description>OCMP3 peripheral</description>
       <baseAddress>0xbf803400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC3CON</name>
@@ -27530,6 +27681,11 @@
       <name>OCMP4</name>
       <description>OCMP4 peripheral</description>
       <baseAddress>0xbf803600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC4CON</name>
@@ -27789,6 +27945,11 @@
       <name>OCMP5</name>
       <description>OCMP5 peripheral</description>
       <baseAddress>0xbf803800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC5CON</name>
@@ -28048,6 +28209,11 @@
       <name>I2C1</name>
       <description>I2C1 peripheral</description>
       <baseAddress>0xbf805000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C1CON</name>
@@ -28812,6 +28978,11 @@
       <name>I2C2</name>
       <description>I2C2 peripheral</description>
       <baseAddress>0xbf805100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C2CON</name>
@@ -29576,6 +29747,11 @@
       <name>SPI1</name>
       <description>SPI1 peripheral</description>
       <baseAddress>0xbf805800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI1CON</name>
@@ -30444,6 +30620,11 @@
       <name>SPI2</name>
       <description>SPI2 peripheral</description>
       <baseAddress>0xbf805a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI2CON</name>
@@ -31312,6 +31493,11 @@
       <name>UART1</name>
       <description>UART1 peripheral</description>
       <baseAddress>0xbf806000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1MODE</name>
@@ -31933,6 +32119,11 @@
       <name>UART2</name>
       <description>UART2 peripheral</description>
       <baseAddress>0xbf806200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U2MODE</name>
@@ -32554,6 +32745,11 @@
       <name>UART3</name>
       <description>UART3 peripheral</description>
       <baseAddress>0xbf806400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U3MODE</name>
@@ -33175,6 +33371,11 @@
       <name>UART4</name>
       <description>UART4 peripheral</description>
       <baseAddress>0xbf806600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U4MODE</name>
@@ -33796,6 +33997,11 @@
       <name>PMP</name>
       <description>PMP peripheral</description>
       <baseAddress>0xbf807000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>PMCON</name>
@@ -34663,6 +34869,11 @@
       <name>ADC10</name>
       <description>ADC10 peripheral</description>
       <baseAddress>0xbf809000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x170</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>AD1CON1</name>
@@ -35442,6 +35653,11 @@
       <name>CVR</name>
       <description>CVR peripheral</description>
       <baseAddress>0xbf809800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CVRCON</name>
@@ -35565,6 +35781,11 @@
       <name>CMP1</name>
       <description>CMP1 peripheral</description>
       <baseAddress>0xbf80a000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM1CON</name>
@@ -35720,6 +35941,11 @@
       <name>CMP2</name>
       <description>CMP2 peripheral</description>
       <baseAddress>0xbf80a010</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM2CON</name>
@@ -35875,6 +36101,11 @@
       <name>CMP</name>
       <description>CMP peripheral</description>
       <baseAddress>0xbf80a060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CMSTAT</name>
@@ -35982,6 +36213,11 @@
       <name>CTMU</name>
       <description>CTMU peripheral</description>
       <baseAddress>0xbf80a200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CTMUCON</name>
@@ -36313,6 +36549,11 @@
       <name>OSC</name>
       <description>OSC peripheral</description>
       <baseAddress>0xbf80f000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OSCCON</name>
@@ -36896,6 +37137,11 @@
       <name>CFG</name>
       <description>CFG peripheral</description>
       <baseAddress>0xbf80f200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xa0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CFGCON</name>
@@ -37729,6 +37975,11 @@
       <name>NVM</name>
       <description>NVM peripheral</description>
       <baseAddress>0xbf80f400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>NVMCON</name>
@@ -37959,6 +38210,11 @@
       <name>RCON</name>
       <description>RCON peripheral</description>
       <baseAddress>0xbf80f600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RCON</name>
@@ -38214,6 +38470,11 @@
       <name>PPS</name>
       <description>PPS peripheral</description>
       <baseAddress>0xbf80fa04</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x2b0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INT1R</name>

--- a/ci/regtest/PIC32MX695F512L.svd
+++ b/ci/regtest/PIC32MX695F512L.svd
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <device>
   <name>PIC32MX695F512L</name>
+  <width>32</width>
   <peripherals>
     <peripheral>
       <name>WDT</name>
       <description>WDT peripheral</description>
       <baseAddress>0xbf800000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>WDTCON</name>
@@ -97,6 +103,11 @@
       <name>RTCC</name>
       <description>RTCC peripheral</description>
       <baseAddress>0xbf800200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RTCCON</name>
@@ -960,6 +971,11 @@
       <name>TMR1</name>
       <description>TMR1 peripheral</description>
       <baseAddress>0xbf800600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T1CON</name>
@@ -1251,6 +1267,11 @@
       <name>TMR2</name>
       <description>TMR2 peripheral</description>
       <baseAddress>0xbf800800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T2CON</name>
@@ -1510,6 +1531,11 @@
       <name>TMR3</name>
       <description>TMR3 peripheral</description>
       <baseAddress>0xbf800a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T3CON</name>
@@ -1753,6 +1779,11 @@
       <name>TMR4</name>
       <description>TMR4 peripheral</description>
       <baseAddress>0xbf800c00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T4CON</name>
@@ -2012,6 +2043,11 @@
       <name>TMR5</name>
       <description>TMR5 peripheral</description>
       <baseAddress>0xbf800e00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>T5CON</name>
@@ -2255,6 +2291,11 @@
       <name>ICAP1</name>
       <description>ICAP1 peripheral</description>
       <baseAddress>0xbf802000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC1CON</name>
@@ -2471,6 +2512,11 @@
       <name>ICAP2</name>
       <description>ICAP2 peripheral</description>
       <baseAddress>0xbf802200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC2CON</name>
@@ -2687,6 +2733,11 @@
       <name>ICAP3</name>
       <description>ICAP3 peripheral</description>
       <baseAddress>0xbf802400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC3CON</name>
@@ -2903,6 +2954,11 @@
       <name>ICAP4</name>
       <description>ICAP4 peripheral</description>
       <baseAddress>0xbf802600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC4CON</name>
@@ -3119,6 +3175,11 @@
       <name>ICAP5</name>
       <description>ICAP5 peripheral</description>
       <baseAddress>0xbf802800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>IC5CON</name>
@@ -3335,6 +3396,11 @@
       <name>OCMP1</name>
       <description>OCMP1 peripheral</description>
       <baseAddress>0xbf803000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC1CON</name>
@@ -3594,6 +3660,11 @@
       <name>OCMP2</name>
       <description>OCMP2 peripheral</description>
       <baseAddress>0xbf803200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC2CON</name>
@@ -3853,6 +3924,11 @@
       <name>OCMP3</name>
       <description>OCMP3 peripheral</description>
       <baseAddress>0xbf803400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC3CON</name>
@@ -4112,6 +4188,11 @@
       <name>OCMP4</name>
       <description>OCMP4 peripheral</description>
       <baseAddress>0xbf803600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC4CON</name>
@@ -4371,6 +4452,11 @@
       <name>OCMP5</name>
       <description>OCMP5 peripheral</description>
       <baseAddress>0xbf803800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x30</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OC5CON</name>
@@ -4630,6 +4716,11 @@
       <name>I2C3</name>
       <description>I2C3 peripheral</description>
       <baseAddress>0xbf805000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C3CON</name>
@@ -5394,6 +5485,11 @@
       <name>I2C4</name>
       <description>I2C4 peripheral</description>
       <baseAddress>0xbf805100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C4CON</name>
@@ -6158,6 +6254,11 @@
       <name>I2C5</name>
       <description>I2C5 peripheral</description>
       <baseAddress>0xbf805200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C5CON</name>
@@ -6922,6 +7023,11 @@
       <name>I2C1</name>
       <description>I2C1 peripheral</description>
       <baseAddress>0xbf805300</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C1CON</name>
@@ -7686,6 +7792,11 @@
       <name>I2C2</name>
       <description>I2C2 peripheral</description>
       <baseAddress>0xbf805400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>I2C2CON</name>
@@ -8450,6 +8561,11 @@
       <name>SPI3</name>
       <description>SPI3 peripheral</description>
       <baseAddress>0xbf805800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI3CON</name>
@@ -9090,6 +9206,11 @@
       <name>SPI2</name>
       <description>SPI2 peripheral</description>
       <baseAddress>0xbf805a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI2CON</name>
@@ -9730,6 +9851,11 @@
       <name>SPI4</name>
       <description>SPI4 peripheral</description>
       <baseAddress>0xbf805c00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI4CON</name>
@@ -10370,6 +10496,11 @@
       <name>SPI1</name>
       <description>SPI1 peripheral</description>
       <baseAddress>0xbf805e00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>SPI1CON</name>
@@ -11010,6 +11141,11 @@
       <name>UART1</name>
       <description>UART1 peripheral</description>
       <baseAddress>0xbf806000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1MODE</name>
@@ -11631,6 +11767,11 @@
       <name>UART4</name>
       <description>UART4 peripheral</description>
       <baseAddress>0xbf806200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U4MODE</name>
@@ -12220,6 +12361,11 @@
       <name>UART3</name>
       <description>UART3 peripheral</description>
       <baseAddress>0xbf806400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U3MODE</name>
@@ -12841,6 +12987,11 @@
       <name>UART6</name>
       <description>UART6 peripheral</description>
       <baseAddress>0xbf806600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U6MODE</name>
@@ -13430,6 +13581,11 @@
       <name>UART2</name>
       <description>UART2 peripheral</description>
       <baseAddress>0xbf806800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U2MODE</name>
@@ -14051,6 +14207,11 @@
       <name>UART5</name>
       <description>UART5 peripheral</description>
       <baseAddress>0xbf806a00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U5MODE</name>
@@ -14640,6 +14801,11 @@
       <name>PMP</name>
       <description>PMP peripheral</description>
       <baseAddress>0xbf807000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>PMCON</name>
@@ -15507,6 +15673,11 @@
       <name>ADC10</name>
       <description>ADC10 peripheral</description>
       <baseAddress>0xbf809000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x170</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>AD1CON1</name>
@@ -16338,6 +16509,11 @@
       <name>CVR</name>
       <description>CVR peripheral</description>
       <baseAddress>0xbf809800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CVRCON</name>
@@ -16461,6 +16637,11 @@
       <name>CMP1</name>
       <description>CMP1 peripheral</description>
       <baseAddress>0xbf80a000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM1CON</name>
@@ -16616,6 +16797,11 @@
       <name>CMP2</name>
       <description>CMP2 peripheral</description>
       <baseAddress>0xbf80a010</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CM2CON</name>
@@ -16771,6 +16957,11 @@
       <name>CMP</name>
       <description>CMP peripheral</description>
       <baseAddress>0xbf80a060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CMSTAT</name>
@@ -16878,6 +17069,11 @@
       <name>OSC</name>
       <description>OSC peripheral</description>
       <baseAddress>0xbf80f000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>OSCCON</name>
@@ -17213,6 +17409,11 @@
       <name>CFG</name>
       <description>CFG peripheral</description>
       <baseAddress>0xbf80f200</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DDPCON</name>
@@ -17310,6 +17511,11 @@
       <name>NVM</name>
       <description>NVM peripheral</description>
       <baseAddress>0xbf80f400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x50</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>NVMCON</name>
@@ -17540,6 +17746,11 @@
       <name>RCON</name>
       <description>RCON peripheral</description>
       <baseAddress>0xbf80f600</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x20</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>RCON</name>
@@ -17779,6 +17990,11 @@
       <name>_DDPSTAT</name>
       <description>_DDPSTAT peripheral</description>
       <baseAddress>0xbf880140</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>_DDPSTAT</name>
@@ -17819,6 +18035,11 @@
       <name>_STRO</name>
       <description>_STRO peripheral</description>
       <baseAddress>0xbf880170</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>_STRO</name>
@@ -17878,6 +18099,11 @@
       <name>_APPO</name>
       <description>_APPO peripheral</description>
       <baseAddress>0xbf880180</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>_APPO</name>
@@ -17937,6 +18163,11 @@
       <name>_APPI</name>
       <description>_APPI peripheral</description>
       <baseAddress>0xbf880190</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>_APPI</name>
@@ -17957,6 +18188,11 @@
       <name>INT</name>
       <description>INT peripheral</description>
       <baseAddress>0xbf881000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x160</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>INTCON</name>
@@ -23137,6 +23373,11 @@
       <name>BMX</name>
       <description>BMX peripheral</description>
       <baseAddress>0xbf882000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>BMXCON</name>
@@ -23555,6 +23796,11 @@
       <name>DMAC</name>
       <description>DMAC peripheral</description>
       <baseAddress>0xbf883000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x60</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DMACON</name>
@@ -24050,6 +24296,11 @@
       <name>DMAC0</name>
       <description>DMAC0 peripheral</description>
       <baseAddress>0xbf883060</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH0CON</name>
@@ -25129,6 +25380,11 @@
       <name>DMAC1</name>
       <description>DMAC1 peripheral</description>
       <baseAddress>0xbf883120</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH1CON</name>
@@ -26208,6 +26464,11 @@
       <name>DMAC2</name>
       <description>DMAC2 peripheral</description>
       <baseAddress>0xbf8831e0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH2CON</name>
@@ -27287,6 +27548,11 @@
       <name>DMAC3</name>
       <description>DMAC3 peripheral</description>
       <baseAddress>0xbf8832a0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH3CON</name>
@@ -28366,6 +28632,11 @@
       <name>DMAC4</name>
       <description>DMAC4 peripheral</description>
       <baseAddress>0xbf883360</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH4CON</name>
@@ -29445,6 +29716,11 @@
       <name>DMAC5</name>
       <description>DMAC5 peripheral</description>
       <baseAddress>0xbf883420</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH5CON</name>
@@ -30524,6 +30800,11 @@
       <name>DMAC6</name>
       <description>DMAC6 peripheral</description>
       <baseAddress>0xbf8834e0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH6CON</name>
@@ -31603,6 +31884,11 @@
       <name>DMAC7</name>
       <description>DMAC7 peripheral</description>
       <baseAddress>0xbf8835a0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xc0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>DCH7CON</name>
@@ -32682,6 +32968,11 @@
       <name>PCACHE</name>
       <description>PCACHE peripheral</description>
       <baseAddress>0xbf884000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0xd0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>CHECON</name>
@@ -33129,6 +33420,11 @@
       <name>USB</name>
       <description>USB peripheral</description>
       <baseAddress>0xbf885040</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x3c0</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>U1OTGIR</name>
@@ -36718,6 +37014,11 @@
       <name>PORTA</name>
       <description>PORTA peripheral</description>
       <baseAddress>0xbf886000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISA</name>
@@ -37637,6 +37938,11 @@
       <name>PORTB</name>
       <description>PORTB peripheral</description>
       <baseAddress>0xbf886040</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISB</name>
@@ -38812,6 +39118,11 @@
       <name>PORTC</name>
       <description>PORTC peripheral</description>
       <baseAddress>0xbf886080</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISC</name>
@@ -39475,6 +39786,11 @@
       <name>PORTD</name>
       <description>PORTD peripheral</description>
       <baseAddress>0xbf8860c0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISD</name>
@@ -40650,6 +40966,11 @@
       <name>PORTE</name>
       <description>PORTE peripheral</description>
       <baseAddress>0xbf886100</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISE</name>
@@ -41441,6 +41762,11 @@
       <name>PORTF</name>
       <description>PORTF peripheral</description>
       <baseAddress>0xbf886140</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISF</name>
@@ -42168,6 +42494,11 @@
       <name>PORTG</name>
       <description>PORTG peripheral</description>
       <baseAddress>0xbf886180</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x70</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>TRISG</name>
@@ -43947,6 +44278,11 @@
       <name>ETH</name>
       <description>ETH peripheral</description>
       <baseAddress>0xbf889000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x330</size>
+        <usage>registers</usage>
+      </addressBlock>
       <registers>
         <register>
           <name>ETHCON1</name>


### PR DESCRIPTION
This PR adds two new elements to SVD output:

* `width` tag for the `device` (hard-coded to 32-bit) ([reference](https://arm-software.github.io/CMSIS_5/SVD/html/elem_device.html)).
* `addressBlock` tags for each `peripheral` ([reference](https://arm-software.github.io/CMSIS_5/SVD/html/elem_peripherals.html#elem_addressBlock)).

These aren't necessary for `svd2rust` (I assume), but adding these allows the output to be used with the current version of the [SVD-Loader-Ghidra](https://github.com/leveldown-security/SVD-Loader-Ghidra) plugin to analyse register accesses.

Thanks very much for building this tool! :)